### PR TITLE
Backup and restore recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,22 @@ This file is used to list changes made in each version of the managed-automate2 
 # 0.1.0
 
 - Initial release.
+- airgap_bundle downloads aib file
+- default recipe installs automate
+
+# 0.2.0
+
+- default recipe configures to pass preflight check
+
+# 0.3.0
+
+- default recipe applies license
+
+# 0.4.0
+
+- relax Chef version to 13 from 14, adding sysctl cookbook
+
+# 0.5.0
+
+- aib as a URL or a file in the default recipe
+- license as a URL or a string in the default recipe

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deploys and configures the Chef Automate 2 server in an airgapped, stateless mod
 
 ## default ##
 
-Installs Chef Automate on a single airgapped box in a new deployment.
+Installs Chef Automate on a single airgapped box in a new deployment. The AIB file may be a URL or a file. The license may be referred as a URL or a string in an attribute.
 
 ## airgap_bundle ##
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@
 # set location to copy the airgap installation bundle and chef-automate command
 default['ma2']['aib']['dir'] = Chef::Config[:file_cache_path]
 default['ma2']['aib']['file'] = 'chef-automate-airgap.aib'
+default['ma2']['aib']['url'] = nil
 
 # set location of the chef-automate CLI
 default['ma2']['cli_path'] = Chef::Config[:file_cache_path]
@@ -32,4 +33,5 @@ default['ma2']['sysctl']['vm.dirty_ratio'] = 15
 default['ma2']['sysctl']['vm.dirty_background_ratio'] = 35
 default['ma2']['sysctl']['vm.dirty_expire_centisecs'] = 20000
 
-default['ma2']['license'] = nil
+default['ma2']['license']['string'] = nil
+default['ma2']['license']['url'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'matt@chef.io'
 license 'Apache-2.0'
 description 'Installs and configures a Chef Automate 2 server'
 long_description 'Installs and configures a Chef Automate 2 server'
-version '0.4.0'
+version '0.5.0'
 chef_version '>= 13' if respond_to?(:chef_version)
 
 supports 'redhat'

--- a/policies/chef-automate2.lock.json
+++ b/policies/chef-automate2.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "ad9c23b020a02289078e37195dade72b20eecb39cc23c40dd9c6eca34860ba11",
+  "revision_id": "fc94d8e340c00f161e875088657093d5832177f89eed27310a87def01fc38665",
   "name": "chef-automate2",
   "run_list": [
     "recipe[managed-automate2::default]"
@@ -18,15 +18,15 @@
   ],
   "cookbook_locks": {
     "managed-automate2": {
-      "version": "0.3.0",
-      "identifier": "a560a60d7e328f9d972349886422c58b76991429",
-      "dotted_decimal_identifier": "46549637464470159.44357749156897826.217202780869673",
+      "version": "0.4.0",
+      "identifier": "64739c2e309721a8f5fc36df1dd3d8ff38aea751",
+      "dotted_decimal_identifier": "28274612298094369.47558259688545747.238590679230289",
       "source": "..",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "git@github.com:mattray/managed-automate2-cookbook.git",
-        "revision": "78795b3f3d348154fe8df59a1e54ded20e67d6df",
+        "revision": "690f12dab05e514f437022e0aedcc35f17c678ba",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -35,6 +35,28 @@
       },
       "source_options": {
         "path": ".."
+      }
+    },
+    "ohai": {
+      "version": "5.2.5",
+      "identifier": "f393ae21b9c53af8a3ee75662fce43f3c2ce5167",
+      "dotted_decimal_identifier": "68560795440104762.69986038791417806.74714224415079",
+      "cache_key": "ohai-5.2.5-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/ohai/versions/5.2.5/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/ohai/versions/5.2.5/download",
+        "version": "5.2.5"
+      }
+    },
+    "sysctl": {
+      "version": "1.0.5",
+      "identifier": "3d2a23146a32c45b9a3635a51b7814c9528f24d5",
+      "dotted_decimal_identifier": "17216303734076100.25783780499594104.22854906094805",
+      "cache_key": "sysctl-1.0.5-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/sysctl/versions/1.0.5/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/sysctl/versions/1.0.5/download",
+        "version": "1.0.5"
       }
     }
   },
@@ -49,11 +71,31 @@
       [
         "managed-automate2",
         ">= 0.0.0"
+      ],
+      [
+        "ohai",
+        "= 5.2.5"
+      ],
+      [
+        "sysctl",
+        "= 1.0.5"
       ]
     ],
     "dependencies": {
-      "managed-automate2 (0.3.0)": [
+      "managed-automate2 (0.4.0)": [
+        [
+          "sysctl",
+          "~> 1.0.5"
+        ]
+      ],
+      "ohai (5.2.5)": [
 
+      ],
+      "sysctl (1.0.5)": [
+        [
+          "ohai",
+          ">= 5.0.0"
+        ]
       ]
     }
   }

--- a/recipes/backup.rb
+++ b/recipes/backup.rb
@@ -27,25 +27,23 @@ directory backupdir
 file backupcommand do
   mode '0700'
   content "#!/bin/sh
+
 # work from a2's backup directory
 cd #{a2backupdir}
+
 # take backup
 /usr/bin/chef-automate backup create --result-json backup-result.json
+
 # backup_id is the timestamp as stored in the JSON log
 backup_id=`cat backup-result.json | sed 's/.*backup_id\":\"\\([0-9]*\\).*/\\1/g'`
-
-# # tar from within the backup directory
-# cd $backup_id
-# # include the JSON in the tarball
-# cp ../backup-result.json .
-# tar -czf #{backupdir}/#{node['ma2']['backup']['prefix']}${backup_id}.tgz backup-result.json *
-# tidy up temporary backup content
-# cd ..
 
 # tar the timestamped backup directory and JSON file
 tar -czf #{backupdir}/#{node['ma2']['backup']['prefix']}${backup_id}.tgz backup-result.json $backup_id
 
+# tidy up
 rm -rf ${backup_id}
+
+# that's all
 "
 end
 

--- a/recipes/backup.rb
+++ b/recipes/backup.rb
@@ -1,9 +1,58 @@
 #
 # Cookbook:: managed-automate2
-# Recipe:: airgap_bundle
+# Recipe:: backup
 #
 
-# pwd
-# /var/opt/chef-automate/backups
-# ls
-# 20180822094505  20180822095735  automate-elasticsearch-data
+# The backup is made to a directory tree under a hardcoded
+# directory which is named by the timestamp of the time of
+# backup.  This value appears to be significant during restore
+# so we need to retain that timestamp.
+#
+# Optional output is the backup-result.json file which contains
+# the timestamp.  We use and include this file when we create a
+# tarball of the backup so we can correctly reconstruct the
+# backup when restoring.
+
+# where we store our backups
+backupdir = node['ma2']['backup']['dir']
+
+# where a2 creates its backups
+a2backupdir = '/var/opt/chef-automate/backups'
+
+backupcommand = a2backupdir + '/backup.sh'
+
+directory backupdir
+
+# shell script for backup
+file backupcommand do
+  mode '0700'
+  content "#!/bin/sh
+# work from a2's backup directory
+cd #{a2backupdir}
+# take backup
+/usr/bin/chef-automate backup create --result-json backup-result.json
+# backup_id is the timestamp as stored in the JSON log
+backup_id=`cat backup-result.json | sed 's/.*backup_id\":\"\\([0-9]*\\).*/\\1/g'`
+
+# # tar from within the backup directory
+# cd $backup_id
+# # include the JSON in the tarball
+# cp ../backup-result.json .
+# tar -czf #{backupdir}/#{node['ma2']['backup']['prefix']}${backup_id}.tgz backup-result.json *
+# tidy up temporary backup content
+# cd ..
+
+# tar the timestamped backup directory and JSON file
+tar -czf #{backupdir}/#{node['ma2']['backup']['prefix']}${backup_id}.tgz backup-result.json $backup_id
+
+rm -rf ${backup_id}
+"
+end
+
+# schedule backup on a recurring cron job. Override attributes as necessary
+cron 'automate-ctl create-backup' do
+  command "cd #{a2backupdir}; #{backupcommand} > /tmp/backup.log 2>&1"
+  minute node['ma2']['backup']['cron']['minute']
+  hour node['ma2']['backup']['cron']['hour']
+  day node['ma2']['backup']['cron']['day']
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,32 @@ fcp = Chef::Config[:file_cache_path]
 aibdir = node['ma2']['aib']['dir']
 aibfile = aibdir + '/' + node['ma2']['aib']['file']
 aibchef = aibdir + '/chef-automate'
+licensefile = fcp + '/automate.license'
+
+# if the aib file is not there download it
+unless node['ma2']['aib']['url'].nil?
+  remote_file aibfile do
+    source node['ma2']['aib']['url']
+    not_if { ::File.exist?(aibfile) }
+  end
+end
+
+# get the license from a URL
+unless node['ma2']['license']['url'].nil?
+  remote_file licensefile do
+    source node['ma2']['license']['url']
+    not_if { ::File.exist?(licensefile) }
+  end
+end
+
+# or get the license from a string
+unless node['ma2']['license']['string'].nil?
+  file licensefile do
+    content node['ma2']['license']['string']
+    sensitive true
+    not_if { ::File.exist?(licensefile) }
+  end
+end
 
 # prepare for preflight-check
 
@@ -27,35 +53,35 @@ aibchef = aibdir + '/chef-automate'
 fs_file_max = `sysctl -n fs.file-max`.strip.to_i
 sysctl_param 'fs.file-max' do
   value node['ma2']['sysctl']['fs.file-max']
-  not_if { 64000 < fs_file_max }
+  not_if { fs_file_max > 64000 }
 end
 
 # vm.max_map_count must be at least 262144
 vm_max_map_count = `sysctl -n vm.max_map_count`.strip.to_i
 sysctl_param 'vm.max_map_count' do
   value node['ma2']['sysctl']['vm.max_map_count']
-  not_if { 262144 < vm_max_map_count }
+  not_if { vm_max_map_count > 262144 }
 end
 
 # vm.dirty_ratio is between 5 and 30
 vm_dirty_ratio = `sysctl -n vm.dirty_ratio`.strip.to_i
 sysctl_param 'vm.dirty_ratio' do
   value node['ma2']['sysctl']['vm.dirty_ratio']
-  not_if { (5 < vm_dirty_ratio) && (vm_dirty_ratio < 30) }
+  not_if { (vm_dirty_ratio > 5) && (vm_dirty_ratio < 30) }
 end
 
 # vm.dirty_background_ratio is between 10 and 60
 vm_dirty_background_ratio = `sysctl -n vm.dirty_background_ratio`.strip.to_i
 sysctl_param 'vm.dirty_background_ratio' do
   value node['ma2']['sysctl']['vm.dirty_background_ratio']
-  not_if { (10 < vm_dirty_background_ratio) && (vm_dirty_background_ratio < 60) }
+  not_if { (vm_dirty_background_ratio > 10) && (vm_dirty_background_ratio < 60) }
 end
 
 # vm.dirty_expire_centisecs must be between 10000 and 30000
 vm_dirty_expire_centisecs = `sysctl -n vm.dirty_expire_centisecs`.strip.to_i
 sysctl_param 'vm.dirty_expire_centisecs' do
   value node['ma2']['sysctl']['vm.dirty_expire_centisecs']
-  not_if { (10000 < vm_dirty_expire_centisecs) && (vm_dirty_expire_centisecs < 30000) }
+  not_if { (vm_dirty_expire_centisecs > 10000) && (vm_dirty_expire_centisecs < 30000) }
 end
 
 # Verify the installation is ready to run Automate 2
@@ -70,16 +96,14 @@ execute "#{aibchef} init-config --upgrade-strategy none" do
 end
 
 # deploy chef automate
-execute "chef-automate deploy" do
+execute 'chef-automate deploy' do
   command "#{aibchef} deploy config.toml --accept-terms-and-mlsa --skip-preflight --airgap-bundle #{aibfile}"
   cwd fcp
   not_if { ::File.exist?("#{fcp}/automate-credentials.toml") }
 end
 
-execute "chef-automate license apply" do
-  command "#{aibchef} license apply #{node['ma2']['license']}"
-  sensitive true
-  not_if { node['ma2']['license'].nil? }
+execute 'chef-automate license apply' do
+  command "#{aibchef} license apply #{licensefile}"
   not_if "#{aibchef} license status | grep '^License ID'"
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,8 +104,11 @@ end
 
 execute 'chef-automate license apply' do
 <<<<<<< HEAD
+<<<<<<< HEAD
   command "#{aibchef} license apply #{licensefile}"
 =======
+=======
+>>>>>>> c299b0ae94a6e72038b3b9a2c66cdc51b19f5c67
   command "#{aibchef} license apply #{node['ma2']['license']}"
   sensitive true
   not_if { node['ma2']['license'].nil? }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -103,16 +103,7 @@ execute 'chef-automate deploy' do
 end
 
 execute 'chef-automate license apply' do
-<<<<<<< HEAD
-<<<<<<< HEAD
   command "#{aibchef} license apply #{licensefile}"
-=======
-=======
->>>>>>> c299b0ae94a6e72038b3b9a2c66cdc51b19f5c67
-  command "#{aibchef} license apply #{node['ma2']['license']}"
-  sensitive true
-  not_if { node['ma2']['license'].nil? }
->>>>>>> Changes for cookstyle compliance
   not_if "#{aibchef} license status | grep '^License ID'"
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -103,7 +103,13 @@ execute 'chef-automate deploy' do
 end
 
 execute 'chef-automate license apply' do
+<<<<<<< HEAD
   command "#{aibchef} license apply #{licensefile}"
+=======
+  command "#{aibchef} license apply #{node['ma2']['license']}"
+  sensitive true
+  not_if { node['ma2']['license'].nil? }
+>>>>>>> Changes for cookstyle compliance
   not_if "#{aibchef} license status | grep '^License ID'"
 end
 

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook:: wbg_a006a_managed-automate2
+# Recipe:: restore
+#
+
+aibdir = node['ma2']['aib']['dir']
+aibfile = aibdir + '/' + node['ma2']['aib']['file']
+aibchef = aibdir + '/chef-automate'
+
+# where we store our backups
+backupdir = node['ma2']['backup']['dir']
+
+# where a2 stores its backups
+a2backupdir = '/var/opt/chef-automate/backups'
+
+rfile = backupdir + '/' + node['ma2']['restore']['file']
+
+# create parent restore directory if backup present
+directory a2backupdir do
+  only_if { !rfile.nil? && ::File.exist?(rfile) }
+end
+
+# unpack backup tarball if JSON doesn't exist
+# (it having been unpacked from a restore
+# or created by an earlier backup)
+
+execute "tar -C #{a2backupdir} -xzf #{rfile}" do
+  # action :nothing
+  # subscribes :run, "directory[#{a2backupdir}]", :immediately
+  action :run
+  only_if { !rfile.nil? && ::File.exist?(rfile) && !File.exist?(a2backupdir + '/backup-result.json') }
+end
+
+execute 'restore automate-2 from backup' do
+  # this restore command assumes that there is only one backup in place: the one we just unpacked
+  command "#{aibchef} backup restore --skip-preflight --airgap-bundle #{aibfile} `#{aibchef} backup list | tail -1 | awk '{print $1}'`"
+  action :nothing
+  subscribes :run, "execute[tar -C #{a2backupdir} -xzf #{rfile}]", :immediately
+end
+
+execute 'clean up restore data' do
+  command "rm -fr #{a2backupdir}/`#{aibchef} backup list | tail -1 | awk '{print $1}'`"
+  action :nothing
+  subscribes :run, 'execute[restore automate-2 from backup]', :immediately
+end

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -8,35 +8,35 @@ describe kernel_parameter('fs.file-max') do
 end
 
 # vm.max_map_count must be at least 262144
-describe kernel_parameter( 'vm.max_map_count') do
+describe kernel_parameter('vm.max_map_count') do
   its('value') { should be >= 262144 }
 end
 
 # vm.dirty_ratio is between 5 and 30
-describe kernel_parameter( 'vm.dirty_ratio') do
+describe kernel_parameter('vm.dirty_ratio') do
   its('value') { should be > 5 }
   its('value') { should be < 30 }
 end
 
 # vm.dirty_background_ratio is between 10 and 60
-describe kernel_parameter( 'vm.dirty_background_ratio') do
+describe kernel_parameter('vm.dirty_background_ratio') do
   its('value') { should be > 10 }
   its('value') { should be < 60 }
 end
 
 # vm.dirty_expire_centisecs must be between 10000 and 30000
-describe kernel_parameter( 'vm.dirty_expire_centisecs') do
+describe kernel_parameter('vm.dirty_expire_centisecs') do
   its('value') { should be >= 10000 }
   its('value') { should be <= 30000 }
 end
 
-describe file "/tmp/kitchen/cache/config.toml" do
+describe file '/tmp/kitchen/cache/config.toml' do
   it { should exist }
   it { should be_file }
   its('content') { should match(/upgrade_strategy = "none"/) }
 end
 
-describe file "/tmp/kitchen/cache/automate-credentials.toml" do
+describe file '/tmp/kitchen/cache/automate-credentials.toml' do
   it { should exist }
   it { should be_file }
   its('content') { should match(/username = "admin"/) }


### PR DESCRIPTION
Implemented recipes for chef-automate backup and restore using local tarballs.

Restore doesn't always complete after a few repeats: it tends to fail with an '86' error.
Logic for preventing repeated restores is based on the presence of the backup-result.json file. This could bear reviewing.

(Also included is some cookstyle recommendations.)